### PR TITLE
Add release badge to README for better visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Search Files Action
-
+[![Release](https://github.com/JanCodeLab/action-search-files/actions/workflows/release.yml/badge.svg)](https://github.com/JanCodeLab/action-search-files/actions/workflows/release.yml)
 This GitHub Action searches for files by extension and provides folder exclusion capabilities. It's built using PowerShell and can be used across your organization.
 
 ## Usage


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a release badge to the top of the file for better visibility of the release status.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2): Added a release badge to the top of the file.